### PR TITLE
Keep previous handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-native-exception-handler
 
 A react native module that lets you to register a global error handler that can capture fatal/non fatal uncaught exceptions.
-The module helps prevent abrupt crashing of RN Apps without a graceful message to the user.   
+The module helps prevent abrupt crashing of RN Apps without a graceful message to the user.
 
 In the current scenario:
   - `In DEV mode , you get a RED Screen error pointing your JS errors.`
@@ -46,9 +46,14 @@ setJSExceptionHandler(errorHandler); // registering the error handler (maybe u c
 or
 
 setJSExceptionHandler(errorHandler, true); //Second argument true is basically
-                                        //if u need the handler to be called in place of RED  
+                                        //if u need the handler to be called in place of RED
                                         //screen in development mode also
-```                                     
+or
+
+setJSExceptionHandler(errorHandler, true, true); //Third argument allows adding it
+                                              //as a new handler, but keeping the previous one
+                                              //(it will run errorHandler but still show the red screen)
+```
 
 
 ### Screens

--- a/examples/seamlessCapture.js
+++ b/examples/seamlessCapture.js
@@ -1,4 +1,3 @@
-import {Alert} from 'react-native';
 import {setJSExceptionHandler} from 'react-native-exception-handler';
 
 const reporter = (error) => {
@@ -10,23 +9,10 @@ const reporter = (error) => {
 const errorHandler = (e, isFatal) => {
   if (isFatal) {
     reporter(e);
-    Alert.alert(
-        'Unexpected error occurred',
-        `
-        Error: ${(isFatal) ? 'Fatal:' : ''} ${e.name} ${e.message}
-
-        We have reported this to our team ! Please close the app and start again!
-        `,
-      [{
-        text: 'Close',
-        onPress: () => {
-          BackAndroid.exitApp();
-        }
-      }]
-    );
   } else {
     console.log(e); // So that we can see it in the ADB logs in case of Android if needed
   }
 };
 
-setJSExceptionHandler(errorHandler);
+// We will still see the error screen, but our reporter() function will be called
+setJSExceptionHandler(errorHandler, false, true);

--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
 const noop = () => {};
 
-export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = false) => {
+export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = false, keepPreviousHandler = false) => {
   const allowed = allowedInDevMode ? true : !__DEV__;
   if (allowed) {
-    global.ErrorUtils.setGlobalHandler(customHandler);
+    if (keepPreviousHandler) {
+      const previousHandler = global.ErrorUtils.getGlobalHandler();
+      global.ErrorUtils.setGlobalHandler((error, isFatal) => {
+        customHandler(error, isFatal);
+        previousHandler(error, isFatal);
+      });
+    } else {
+      global.ErrorUtils.setGlobalHandler(customHandler);
+    }
   } else {
     console.log('Skipping setJSExceptionHandler: Reason: In DEV mode and allowedInDevMode = false');
   }


### PR DESCRIPTION
This adds a new boolean parameter to `setJSExceptionHandler`, `keepPreviousHandler`. When set to `true`, it stores the previous handler function and calls it after calling the newly set exception handler. This allows developers to keep the previous functionality (red screen) intact, while still capturing errors (i.e. for analytics purposes).