### PR TITLE
Remove createJSModules override for RN 47.0

### DIFF
--- a/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerPackage.java
+++ b/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerPackage.java
@@ -16,7 +16,6 @@ public class ReactNativeExceptionHandlerPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new ReactNativeExceptionHandlerModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Removed the @override but left the function for backward compatibility per the discussion here: https://github.com/facebook/react-native/issues/15232