### PR TITLE
Fix podspec for integration with CocoaPods

### DIFF
--- a/ios/ReactNativeExceptionHandler.podspec
+++ b/ios/ReactNativeExceptionHandler.podspec
@@ -1,24 +1,20 @@
 
 Pod::Spec.new do |s|
   s.name         = "ReactNativeExceptionHandler"
+  s.summary      = "A react native module that lets you to register a global error handler that can capture fatal/non fatal uncaught exceptions"
   s.version      = "1.0.0"
-  s.summary      = "ReactNativeExceptionHandler"
   s.description  = <<-DESC
-                  ReactNativeExceptionHandler
+                   A react native module that lets you to register a global error handler that can capture fatal/non fatal uncaught exceptions.
+                   The module helps prevent abrupt crashing of RN Apps without a graceful message to the user.
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/master-atul/react-native-exception-handler"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.author       = { "Atul R" => "atulanand94@gmail.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/ReactNativeExceptionHandler.git", :tag => "master" }
   s.source_files  = "ReactNativeExceptionHandler/**/*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
 
 end
-
-  

--- a/ios/ReactNativeExceptionHandler.podspec
+++ b/ios/ReactNativeExceptionHandler.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
   s.name         = "ReactNativeExceptionHandler"
   s.summary      = "A react native module that lets you to register a global error handler that can capture fatal/non fatal uncaught exceptions"
-  s.version      = "1.0.0"
+  s.version      = "2.1.0"
   s.description  = <<-DESC
                    A react native module that lets you to register a global error handler that can capture fatal/non fatal uncaught exceptions.
                    The module helps prevent abrupt crashing of RN Apps without a graceful message to the user.


### PR DESCRIPTION
Hi, I want integrate your project with CocoaPods but get this error:

```
Fetching podspec for `ReactNativeExceptionHandler` from `../node_modules/react-native-exception-handler/ios`
[!] The `ReactNativeExceptionHandler` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

This PR contains changes for the Podspec file which make it possible to integrate your library in the Podfile like this:

```
  # react-native-exception-handler
  pod 'ReactNativeExceptionHandler', :path => '../node_modules/react-native-exception-handler/ios'
```