### PR TITLE
react-native-navigation (wix) fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,14 @@ setNativeExceptionHandler((errorString) => {
 *More Examples can be found in the examples folder*
 - Preserving old handler (thanks to zeh)
 
+#### react-native-navigation (Wix)
+
+When you use the [wix library](http://wix.github.io/react-native-navigation/) to navigate, you need to add a *false* parameter to _setNativeExceptionHandler_. Otherwise it will recreate the application above the crash screen.
+
+```js
+setNativeExceptionHandler(nativeErrorCallback, false);
+```
+
 
 ## CONTRIBUTORS
 - [Atul R](https://github.com/master-atul)

--- a/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
+++ b/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
@@ -50,6 +50,8 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
               i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             
               activity.startActivity(i);
+              activity.finish();
+            
               if (forceToQuit)
                 System.exit(0);
           }

--- a/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
+++ b/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
@@ -14,6 +14,7 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
   private ReactApplicationContext reactContext;
     private Activity activity;
     private static Class errorIntentTargetClass = DefaultErrorScreen.class;
+    private boolean forceToQuit;
     private Callback callbackHolder;
 
     public ReactNativeExceptionHandlerModule(ReactApplicationContext reactContext) {
@@ -28,21 +29,29 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
 
 
   @ReactMethod
-  public void setHandlerforNativeException(Callback customHandler){
-      callbackHolder = customHandler;
+  public void setHandlerforNativeException(final boolean forceToQuit, Callback customHandler){
+      this.callbackHolder = customHandler;
+      this.forceToQuit = forceToQuit;
+    
       Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
           @Override
           public void uncaughtException(Thread thread, Throwable throwable) {
               activity = getCurrentActivity();
               String stackTraceString = Log.getStackTraceString(throwable);
               callbackHolder.invoke(stackTraceString);
-              Log.d("ERROR",stackTraceString);
+            
+              if (BuildConfig.DEBUG) {
+                  Log.d("ERROR",stackTraceString);
+              }
+            
               Intent i = new Intent();
               i.setClass(activity, errorIntentTargetClass);
               i.putExtra("stack_trace_string",stackTraceString);
               i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            
               activity.startActivity(i);
-              System.exit(0);
+              if (forceToQuit)
+                System.exit(0);
           }
       });
   }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-import {NativeModules} from 'react-native';
+import {NativeModules, Platform} from 'react-native';
 
 const {ReactNativeExceptionHandler} = NativeModules;
 
@@ -21,7 +21,12 @@ export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplic
   if (typeof customErrorHandler !== 'function') {
     customErrorHandler = noop;
   }
-  ReactNativeExceptionHandler.setHandlerforNativeException(forceApplicationToQuit, customErrorHandler);
+  
+  if (Platform.OS === 'ios') {
+    ReactNativeExceptionHandler.setHandlerforNativeException(customErrorHandler);
+  } else {
+    ReactNativeExceptionHandler.setHandlerforNativeException(forceApplicationToQuit, customErrorHandler);
+  }
 };
 
 export default {

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = f
 
 export const getJSExceptionHandler = () => global.ErrorUtils.getGlobalHandler();
 
-export const setNativeExceptionHandler = (customErrorHandler = noop) => {
+export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplicationToQuit = true) => {
   if (typeof customErrorHandler !== 'function') {
     customErrorHandler = noop;
   }
-  ReactNativeExceptionHandler.setHandlerforNativeException(customErrorHandler);
+  ReactNativeExceptionHandler.setHandlerforNativeException(forceApplicationToQuit, customErrorHandler);
 };
 
 export default {


### PR DESCRIPTION
Hey man, I was initiating using your lib but it has a problema with wix navigation lib. When you call System.exit(0) and start a new activity, the hole application is launched again. By doing this I can prevent the restart of the app and show the error activity.