### PR TITLE
Fix Android parameters ordering

### DIFF
--- a/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
+++ b/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
@@ -28,7 +28,7 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
 
 
   @ReactMethod
-  public void setHandlerforNativeException(Callback customHandler, final boolean forceToQuit){
+  public void setHandlerforNativeException(final boolean forceToQuit, Callback customHandler){
       callbackHolder = customHandler;
 
       Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,20 @@ export const setJSExceptionHandler = (customHandler = noop, allowedInDevMode = f
 
 export const getJSExceptionHandler = () => global.ErrorUtils.getGlobalHandler();
 
-export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplicationToQuit = true) => {
+export const setNativeExceptionHandler = (forceApplicationToQuit = true, customErrorHandler = noop) => {
+  var handler = customErrorHandler;
+
+  // backward compatible API
+  if (typeof forceApplicationToQuit === 'function') {
+    handler = forceApplicationToQuit;
+  }
+
+  if (typeof customErrorHandler === 'boolean') {
+    forceApplicationToQuit = customErrorHandler;
+  }
+
+  customErrorHandler = handler;
+
   if (typeof customErrorHandler !== 'function') {
     customErrorHandler = noop;
   }
@@ -25,7 +38,7 @@ export const setNativeExceptionHandler = (customErrorHandler = noop, forceApplic
   if (Platform.OS === 'ios') {
     ReactNativeExceptionHandler.setHandlerforNativeException(customErrorHandler);
   } else {
-    ReactNativeExceptionHandler.setHandlerforNativeException(customErrorHandler, forceApplicationToQuit);
+    ReactNativeExceptionHandler.setHandlerforNativeException(forceApplicationToQuit, customErrorHandler);
   }
 };
 


### PR DESCRIPTION
The current implementation raises "cannot have non-function argument after a function arg"
as of RN v0.48+.

This patch fixes this issue inverting the order of the arguments in the native implementation.
Proper checks are in place to make this change backward compatible and detect the previous API usage, switching the parameters as needed.