### PR TITLE
Fix issue with CocoaPods

### DIFF
--- a/ios/ReactNativeExceptionHandler.podspec
+++ b/ios/ReactNativeExceptionHandler.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { "Atul R" => "atulanand94@gmail.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/ReactNativeExceptionHandler.git", :tag => "master" }
-  s.source_files  = "ReactNativeExceptionHandler/**/*.{h,m}"
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"


### PR DESCRIPTION
CocoaPods can not include source files due to using relative path of podspec.