### PR TITLE
Change import priority of RCTBridgeModule

### DIFF
--- a/ios/ReactNativeExceptionHandler.h
+++ b/ios/ReactNativeExceptionHandler.h
@@ -1,8 +1,8 @@
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 #import  <UIKit/UIKit.h>


### PR DESCRIPTION
This appears to be the accepted fix for this issue: https://github.com/master-atul/react-native-exception-handler/issues/46 per https://github.com/facebook/react-native/issues/15775#issuecomment-326930316 and other posts in the same thread.

Thanks for the great library!