### PR TITLE
Save and call pre-existing native handler on Android

### DIFF
--- a/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
+++ b/android/src/main/java/com/masteratul/exceptionhandler/ReactNativeExceptionHandlerModule.java
@@ -15,6 +15,7 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
     private Activity activity;
     private static Class errorIntentTargetClass = DefaultErrorScreen.class;
     private Callback callbackHolder;
+    private Thread.UncaughtExceptionHandler originalHandler;
 
     public ReactNativeExceptionHandlerModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -30,6 +31,7 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
   @ReactMethod
   public void setHandlerforNativeException(final boolean forceToQuit, Callback customHandler){
       callbackHolder = customHandler;
+      originalHandler = Thread.getDefaultUncaughtExceptionHandler();
 
       Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
           @Override
@@ -47,7 +49,11 @@ public class ReactNativeExceptionHandlerModule extends ReactContextBaseJavaModul
             
               activity.startActivity(i);
               activity.finish();
-            
+
+              if (originalHandler != null) {
+                  originalHandler.uncaughtException(thread, throwable);
+              }
+
               if (forceToQuit) {
                 System.exit(0);
               }


### PR DESCRIPTION
This is in part a workaround to #62 (since I can't manually call that pre-existing handler) but I think it's generally better behavior for react-native-exception-handler to not completely overwrite pre-existing native handlers.

Fixes #65

This should also be done for the iOS native handler but I am having other issues with the iOS native handler code (see issue #63) so I couldn't properly test it.  I've filed #66 for that.